### PR TITLE
Join Log Changes

### DIFF
--- a/src/modules/functions/general/index.js
+++ b/src/modules/functions/general/index.js
@@ -9,6 +9,7 @@ const secrets = require('../../../../secrets.json')
 const { addtoRoleQueue, attemptRoleQueue } = require('../api/v3rm/userSetup')
 const { logMember } = require('../database/members')
 const log = require('../../../mongo/log')
+const { logJoin } = require('../../../mongo/joins')
 
 const errorReasonTransform = (err) => {
   if (err === 'Input malformed') return 'There was an issue with your input. Please use `!lookup @User` or `!lookup id`.'
@@ -97,6 +98,7 @@ const performBasicLookup = async (member) => {
   const aChannel = cache.get(activationLog)
 
   const logLookup = await aChannel.send(genSpinner(`Looking up new member: ${member.user.tag} / ${member.user.id}`))
+  await logJoin(member.guild.id, member.id, logLookup.id) // Save to database
   const details = await lookup(member.id, member.guild.id, { bypass: true, type: 'basicLookup' }).catch(() => { })
   if (!details) {
     logLookup.edit(genericLinkInfo(member, 'User is not linked.'))

--- a/src/modules/functions/moderation/raysA.js
+++ b/src/modules/functions/moderation/raysA.js
@@ -100,7 +100,7 @@ const isBotAndMuteChuu = (message) => {
   if (!message.author.bot) return false
   if (message.member.roles.cache.find((role) => role.id === message.guild.ver.roles.chuu)) {
     if (Date.now() >= nextChuu) {
-      nextChuu = Date.now() + 600000
+      nextChuu = Date.now() + 60000
       safeDelete(message, 0)
     }
   }

--- a/src/mongo/joins.js
+++ b/src/mongo/joins.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose')
+const joinSchema = require('./schemas/joinlog')
+
+const Joinlog = mongoose.model('joinlog', joinSchema)
+
+const logJoin = async (serverId, id, messageId) => {
+  const query = { serverId, id }
+  const theLog = {
+    messageId,
+  }
+  const options = { upsert: true, new: false, setDefaultsOnInsert: true }
+
+  const result = await Joinlog.findOneAndUpdate(query, { $set: theLog }, options)
+  return result
+}
+
+const fetchJoin = async (serverId, id) => {
+  const query = { serverId, id }
+  const theLog = await Joinlog.findOne(query)
+  if (!theLog) return null
+  return theLog.messageId
+}
+
+const deleteJoin = async (serverId, id) => {
+  const query = { serverId, id }
+  await Joinlog.deleteOne(query)
+}
+
+module.exports = { logJoin, fetchJoin, deleteJoin }

--- a/src/mongo/schemas/joinlog.js
+++ b/src/mongo/schemas/joinlog.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose')
+
+const { Schema } = mongoose
+
+const joinSchema = new Schema({
+  serverId: { type: String },
+  id: { type: String },
+  messageId: { type: String },
+})
+
+module.exports = joinSchema


### PR DESCRIPTION
- Store joins in db, along with a reference to the message logging their join.
- When they activate, update that message as opposed to sending a new one.